### PR TITLE
rectifying error in TOURS Header background

### DIFF
--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -54,23 +54,18 @@ body {
   width: 2000px;
 }
 
-.col-12
-{
+.col-12{
   background-image: url(/images/lake.jpg);
-  background-position: center;
-  background-repeat: no-repeat;
   background-size: contain;
   background-attachment: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
   background-origin: initial;
 }
 
 .circle{
   border-radius:50%;
   margin-left: 50px;
-}
-
-.col-12{
-  background-image: url(/images/frankfurt.jpg);
 }
 
 .space{


### PR DESCRIPTION
there was an error that the Frankfurt.jpg (image) was being considered for the Tours heading background instead of lake.jpg(image) there was the exact class name being used to apply background to both the images & the code was considering the Frankfurt.jpg for the background which had to be removed and changed to lake.jpg with other necessary changes.